### PR TITLE
Rename inchikey to stdinchikey, introduce proper inchikey

### DIFF
--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -16,3 +16,10 @@ properties:
       sortable: false
       query-support: "none"
       response-level: "yes"
+  _cheminfo_stdinchikey:
+    $$inherit: "/properties/structures/_cheminfo_stdinchikey"
+    x-optimade-implementation:
+      support: "may"
+      sortable: false
+      query-support: "none"
+      response-level: "yes"

--- a/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
@@ -16,4 +16,5 @@ description: |-
   It can be any InChIKey: not necessary a Standard InChIKey, but can also be the latter.
 examples:
   - "QZAYGJVTTNCVMB-UHFFFAOYSA-N"
+  - "QZAYGJVTTNCVMB-UHFFFAOYNA-N"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
@@ -1,6 +1,6 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
 $id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_inchikey"
-title: "InChIKey identifier of the structure, as laid out by the InChI Trust"
+title: "InChIKey identifier of the structure as defined by the InChI Trust"
 x-optimade-type: "string"
 x-optimade-definition:
   kind: "property"

--- a/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
@@ -12,7 +12,7 @@ type:
   - "string"
   - "null"
 description: |-
-  An InChIKey identifier of the structure, as laid out by the InChI Trust (https://www.inchi-trust.org).
+  An InChIKey identifier of the structure as defined by the InChI Trust (https://www.inchi-trust.org).
   It can be any InChIKey: not necessary a Standard InChIKey, but can also be the latter.
 examples:
   - "QZAYGJVTTNCVMB-UHFFFAOYSA-N"

--- a/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_inchikey.yaml
@@ -14,6 +14,7 @@ type:
 description: |-
   An InChIKey identifier of the structure as defined by the InChI Trust (https://www.inchi-trust.org).
   It can be any InChIKey: not necessary a Standard InChIKey, but can also be the latter.
+  InChIKey is not guaranteed to be unique and in extremely rare cases the same InChIKey may be assigned to several different structures.
 examples:
   - "QZAYGJVTTNCVMB-UHFFFAOYSA-N"
   - "QZAYGJVTTNCVMB-UHFFFAOYNA-N"

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
@@ -13,7 +13,7 @@ type:
   - "null"
 description: |-
   The standard InChIKey identifier of the structure as defined by the InChI Trust (https://www.inchi-trust.org).
-  Standard InChIKey is not guaranteed to be unique and in extremely rare cases the same InChIKey may be assigned to several different structures.
+  A standard InChIKey is not guaranteed to be unique and in extremely rare cases the same InChIKey may be assigned to several different structures.
 examples:
   - "QZAYGJVTTNCVMB-UHFFFAOYSA-N"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
@@ -1,13 +1,13 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
-$id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_inchikey"
+$id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_stdinchikey"
 title: "The standard InChIKey identifier of the structure, as laid out by the InChI Trust"
 x-optimade-type: "string"
 x-optimade-definition:
   kind: "property"
   version: "0.1.0"
   format: "1.2"
-  name: "_cheminfo_inchikey"
-  label: "_cheminfo_inchikey_structures"
+  name: "_cheminfo_stdinchikey"
+  label: "_cheminfo_stdinchikey_structures"
 type:
   - "string"
   - "null"

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
@@ -1,6 +1,6 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
 $id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_stdinchikey"
-title: "The standard InChIKey identifier of the structure, as laid out by the InChI Trust"
+title: "The standard InChIKey identifier of the structure as defined by the InChI Trust"
 x-optimade-type: "string"
 x-optimade-definition:
   kind: "property"

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
@@ -1,6 +1,6 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
 $id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_inchikey"
-title: "InChIKey identifier of the structure, as laid out by the InChI Trust"
+title: "The standard InChIKey identifier of the structure, as laid out by the InChI Trust"
 x-optimade-type: "string"
 x-optimade-definition:
   kind: "property"
@@ -12,8 +12,8 @@ type:
   - "string"
   - "null"
 description: |-
-  An InChIKey identifier of the structure, as laid out by the InChI Trust (https://www.inchi-trust.org).
-  It can be any InChIKey: not necessary a Standard InChIKey, but can also be the latter.
+  The standard InChIKey identifier of the structure, as laid out by the InChI Trust (https://www.inchi-trust.org).
+  Standard InChIKey is not guaranteed to be unique and in extremely rare cases the same InChIKey may be assigned to several different structures.
 examples:
   - "QZAYGJVTTNCVMB-UHFFFAOYSA-N"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchikey.yaml
@@ -12,7 +12,7 @@ type:
   - "string"
   - "null"
 description: |-
-  The standard InChIKey identifier of the structure, as laid out by the InChI Trust (https://www.inchi-trust.org).
+  The standard InChIKey identifier of the structure as defined by the InChI Trust (https://www.inchi-trust.org).
   Standard InChIKey is not guaranteed to be unique and in extremely rare cases the same InChIKey may be assigned to several different structures.
 examples:
   - "QZAYGJVTTNCVMB-UHFFFAOYSA-N"


### PR DESCRIPTION
There appears to be two flavors of InChIKey: Standard and non-standard. Standard InChIKey is based on Standard InChI and is supposed to be unique(-ish), meaning that there should be 1:1 relation between a structure and its InChIKey. (Of course there are collisions, but they are pretty rare).

Then there is a non-standard InChIKey, based on non-standard InChI. These seem to sometimes contain more information than Standard InChI, namely tautomeric hydrogen positions and even connections between metal atoms.

This PR renames `_cheminfo_inchikey` to `_cheminfo_stdinchikey` and re-introduces `_cheminfo_inchikey` for non-standard InChIKey.