### PR TITLE
Introduce Preferred IUPAC Name property

### DIFF
--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -16,6 +16,13 @@ properties:
       sortable: false
       query-support: "none"
       response-level: "yes"
+  _cheminfo_preferred_iupac_name:
+    $$inherit: "/properties/structures/_cheminfo_preferred_iupac_name"
+    x-optimade-implementation:
+      support: "may"
+      sortable: false
+      query-support: "none"
+      response-level: "yes"
   _cheminfo_stdinchikey:
     $$inherit: "/properties/structures/_cheminfo_stdinchikey"
     x-optimade-implementation:

--- a/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
@@ -13,7 +13,7 @@ type:
   - "null"
 description: |-
   A unique name for a chemical compound defined according to the rules of Preferred IUPAC Names (PINs).
-  The rules for PINs are laid out in "Nomenclature of Organic Chemistry. IUPAC Recommendations and Preferred Names 2013", also known as the Blue Book (https://iupac.qmul.ac.uk/BlueBook/).
+  The rules for PINs are provided in "Nomenclature of Organic Chemistry. IUPAC Recommendations and Preferred Names 2013", also known as the Blue Book (https://iupac.qmul.ac.uk/BlueBook/).
   Usage of the Blue Book version 3 (2023-12-06) is RECOMMENDED.
 examples:
   - "1-ethoxypropane"

--- a/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
@@ -1,0 +1,22 @@
+$$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
+$id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_preferred_iupac_name"
+title: "Preferred IUPAC name"
+x-optimade-type: "string"
+x-optimade-definition:
+  kind: "property"
+  version: "0.1.0"
+  format: "1.2"
+  name: "_cheminfo_preferred_iupac_name"
+  label: "_cheminfo_preferred_iupac_name_structures"
+type:
+  - "string"
+  - "null"
+description: |-
+  A unique name for a chemical compound defined according to the rules of Preferred IUPAC Names (PINs).
+  The rules for PINs are laid out in "Nomenclature of Organic Chemistry. IUPAC Recommendations and Preferred Names 2013", also known as Blue Book (https://iupac.qmul.ac.uk/BlueBook/).
+  Usage of Blue Book version 3 (2023-12-06) is RECOMMENDED.
+examples:
+  - "1-ethoxypropane"
+  - "2,5,8,11-tetraoxatridecane"
+  - "7,7-dimethylbicyclo[2.2.1]heptane"
+x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
@@ -14,7 +14,7 @@ type:
 description: |-
   A unique name for a chemical compound defined according to the rules of Preferred IUPAC Names (PINs).
   The rules for PINs are laid out in "Nomenclature of Organic Chemistry. IUPAC Recommendations and Preferred Names 2013", also known as the Blue Book (https://iupac.qmul.ac.uk/BlueBook/).
-  Usage of Blue Book version 3 (2023-12-06) is RECOMMENDED.
+  Usage of the Blue Book version 3 (2023-12-06) is RECOMMENDED.
 examples:
   - "1-ethoxypropane"
   - "2,5,8,11-tetraoxatridecane"

--- a/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_preferred_iupac_name.yaml
@@ -13,7 +13,7 @@ type:
   - "null"
 description: |-
   A unique name for a chemical compound defined according to the rules of Preferred IUPAC Names (PINs).
-  The rules for PINs are laid out in "Nomenclature of Organic Chemistry. IUPAC Recommendations and Preferred Names 2013", also known as Blue Book (https://iupac.qmul.ac.uk/BlueBook/).
+  The rules for PINs are laid out in "Nomenclature of Organic Chemistry. IUPAC Recommendations and Preferred Names 2013", also known as the Blue Book (https://iupac.qmul.ac.uk/BlueBook/).
   Usage of Blue Book version 3 (2023-12-06) is RECOMMENDED.
 examples:
   - "1-ethoxypropane"


### PR DESCRIPTION
Preferred IUPAC Name (PIN) is supposed to be a unique, both human- and machine-readable name for a chemical compound (usually organic). They look like this:
* 1-ethoxypropane
* 2,5,8,11-tetraoxatridecane
* 7,7-dimethylbicyclo[2.2.1]heptane

There are pieces of software, most prominently [OPSIN](https://opsin.ch.cam.ac.uk) which can unambiguously derive chemical structure from these names. Having such property would be an alternative to SMILES, InChI and the like. One downside of PINs is that they are somewhat difficult to derive from chemical structures and that the PIN derivation rules are from time to time refined.