### PR TITLE
Introduce SMILES property

### DIFF
--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -25,7 +25,8 @@ properties:
     $$inherit: "/properties/structures/_cheminfo_smiles"
     x-optimade-implementation:
       sortable: false
-      query-support: "none"
+      query-support: "partial"
+      query-support-operators: ['=', '!=', 'CONTAINS', 'IS KNOWN', 'IS UNKNOWN']
       response-default: true
   _cheminfo_stdinchi:
     $$inherit: "/properties/structures/_cheminfo_stdinchi"

--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -23,6 +23,13 @@ properties:
       sortable: false
       query-support: "none"
       response-level: "yes"
+  _cheminfo_smiles:
+    $$inherit: "/properties/structures/_cheminfo_smiles"
+    x-optimade-implementation:
+      support: "may"
+      sortable: false
+      query-support: "none"
+      response-level: "yes"
   _cheminfo_stdinchikey:
     $$inherit: "/properties/structures/_cheminfo_stdinchikey"
     x-optimade-implementation:

--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -26,10 +26,9 @@ properties:
   _cheminfo_smiles:
     $$inherit: "/properties/structures/_cheminfo_smiles"
     x-optimade-implementation:
-      support: "may"
       sortable: false
       query-support: "none"
-      response-level: "yes"
+      response-default: true
   _cheminfo_stdinchi:
     $$inherit: "/properties/structures/_cheminfo_stdinchi"
     x-optimade-implementation:

--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -25,8 +25,7 @@ properties:
     $$inherit: "/properties/structures/_cheminfo_smiles"
     x-optimade-implementation:
       sortable: false
-      query-support: "partial"
-      query-support-operators: ['=', '!=', 'IS KNOWN', 'IS UNKNOWN']
+      query-support: "equality only"
       response-default: true
   _cheminfo_stdinchi:
     $$inherit: "/properties/structures/_cheminfo_stdinchi"

--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -26,7 +26,7 @@ properties:
     x-optimade-implementation:
       sortable: false
       query-support: "partial"
-      query-support-operators: ['=', '!=', 'CONTAINS', 'IS KNOWN', 'IS UNKNOWN']
+      query-support-operators: ['=', '!=', 'IS KNOWN', 'IS UNKNOWN']
       response-default: true
   _cheminfo_stdinchi:
     $$inherit: "/properties/structures/_cheminfo_stdinchi"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -43,10 +43,21 @@ x-optimade-metadata-definition:
         - "IUPAC SMILES+"
         - "OpenSMILES"
       x-optimade-unit: "inapplicable"
+    _cheminfo_standard_name_other:
+      description: |-
+        A name of the standard the given SMILES string conforms to, if different from the enumerator values for '_cheminfo_standard_name'.
+      x-optimade-type: "string"
+      type:
+        - "string"
+      examples:
+        - "Daylight"
+        - "OpenBabel"
+      x-optimade-unit: "inapplicable"
     _cheminfo_standard_version:
       description: |-
         The version of the SMILES standard given in '_cheminfo_standard_name'.
         MUST NOT contain the initial 'v' or 'V'.
+        If '_cheminfo_standard_name_other' contains the name of a software library used to generate SMILES, '_cheminfo_standard_version' MUST be the version of this software library.
       x-optimade-type: "string"
       type:
         - "string"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -12,7 +12,11 @@ type:
   - "string"
   - "null"
 description: |-
-  SMILES string describing a chemical compound.
+  SMILES (Simplified Molecular Input Line Entry System) representation of the structure.
+  Values MUST adhere to the OpenSMILES specification v1.0 (http://opensmiles.org/opensmiles.html).
+  When structures or their parts cannot be unambiguously represented in SMILES according to OpenSMILES recommendations, using the guidelines from Quirós et al. 2018 (https://doi.org/10.1186/s13321-018-0279-6) is RECOMMENDED.
+  Providers MAY canonicalize (i.e., use rules to establish the stable order of atoms) the produced SMILES representations, but this is not mandatory and no particular set of rules is recommended.
+  Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
 examples:
   - "c1ccccc1"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -31,7 +31,7 @@ x-optimade-metadata-definition:
   properties:
     _cheminfo_standard:
       description: |-
-        A name of a standard the given SMILES string conforms to.
+        A name of the standard the given SMILES string conforms to.
       examples:
         - "OpenSMILES"
         - "IUPAC SMILES+"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -43,5 +43,16 @@ x-optimade-metadata-definition:
         - "IUPAC SMILES+"
         - "OpenSMILES"
       x-optimade-unit: "inapplicable"
+    _cheminfo_standard_version:
+      description: |-
+        The version of the SMILES standard given in '_cheminfo_standard_name'.
+        MUST NOT contain the initial 'v' or 'V'.
+      x-optimade-type: "string"
+      type:
+        - "string"
+      examples:
+        - "1.0"
+        - "a76e26b32e6f0d18f7dd0cadf1b23449baebb04e"
+      x-optimade-unit: "inapplicable"
   x-optimade-unit: "inapplicable"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -19,6 +19,7 @@ description: |-
   In the filtering context, this field behaves differently to a normal string.
   Firstly, this property can be used with the `CONTAINS` operator to provide a substructure query using the SMILES Arbitrary Target Specification (SMARTS) language defined in the Daylight SMARTS documentation (https://www.daylight.com/dayhtml/doc/theory/theory.smarts.html).
   Secondly, exact matches using the `=` operator have additional semantics that allow a server to canonicalize the SMILES value before performing the exact match comparison, i.e., a server implementation SHOULD attempt to convert a user query for an exact SMILES match into the particular SMILES format used by the database, whereupon it can return entries that have SMILES data that matches at the semantic rather than lexical level.
+  Finally, `IS KNOWN` and `IS UNKNOWN` operators MAY be used to filter entries having non-`null` and `null` values of this property, accordingly.
 examples:
   - "c1ccccc1"
   - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -31,7 +31,7 @@ x-optimade-metadata-definition:
     _cheminfo_standard_name:
       description: |-
         A name of the standard the given SMILES string conforms to.
-        Takes value from an enumerator containing: 'IUPAC SMILES+' (https://github.com/IUPAC/IUPAC_SMILES_plus), 'OpenSMILES' (http://opensmiles.org/opensmiles.html) and 'other' (none of the above).
+        Takes value from an enumeration set containing 'IUPAC SMILES+' (https://github.com/IUPAC/IUPAC_SMILES_plus), 'OpenSMILES' (http://opensmiles.org/opensmiles.html) and 'other' (none of the above).
       x-optimade-type: "string"
       type:
         - "string"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -1,7 +1,7 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
 $id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_smiles"
 title: "SMILES (Simplified Molecular Input Line Entry System) representation of the structure"
-x-optimade-type: "string"
+x-optimade-type: "_cheminfo_smiles"
 x-optimade-definition:
   kind: "property"
   version: "0.1.0"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -36,6 +36,7 @@ x-optimade-metadata-definition:
       description: |-
         A name of the specification the given SMILES string conforms to.
         Takes value from an enumeration set containing 'IUPAC SMILES+' (https://github.com/IUPAC/IUPAC_SMILES_plus), 'OpenSMILES' (http://opensmiles.org/opensmiles.html) and 'other' (none of the above).
+        If 'other' is chosen, the specification MUST be specified in metadata property '_cheminfo_specification_name_other'.
       x-optimade-type: "string"
       type:
         - "string"
@@ -50,7 +51,7 @@ x-optimade-metadata-definition:
       x-optimade-unit: "inapplicable"
     _cheminfo_specification_name_other:
       description: |-
-        A name of the specification the given SMILES string conforms to, if different from the enumerator values for '_cheminfo_specification_name'.
+        A name of the specification the given SMILES string conforms to, if different from the enumerator values for metadata property '_cheminfo_specification_name'.
         MUST be defined (non-NULL) if and only if the value for '_cheminfo_specification_name' is known and is equal to 'other'.
       x-optimade-type: "string"
       type:
@@ -62,7 +63,7 @@ x-optimade-metadata-definition:
       x-optimade-unit: "inapplicable"
     _cheminfo_specification_version:
       description: |-
-        The version of the SMILES specification given in '_cheminfo_specification_name'.
+        The version of the SMILES specification given in metadata property '_cheminfo_specification_name'.
         If '_cheminfo_specification_name_other' contains the name of a software library used to generate SMILES, '_cheminfo_specification_version' MUST be the version of this software library.
       x-optimade-type: "string"
       type:

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -34,6 +34,7 @@ x-optimade-metadata-definition:
       x-optimade-type: "string"
       type:
         - "string"
+        - "null"
       enum:
         - "IUPAC SMILES+"
         - "OpenSMILES"
@@ -48,6 +49,7 @@ x-optimade-metadata-definition:
       x-optimade-type: "string"
       type:
         - "string"
+        - "null"
       examples:
         - "Daylight"
         - "OpenBabel"
@@ -59,6 +61,7 @@ x-optimade-metadata-definition:
       x-optimade-type: "string"
       type:
         - "string"
+        - "null"
       examples:
         - "1.0"
         - "a76e26b32e6f0d18f7dd0cadf1b23449baebb04e"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -24,7 +24,6 @@ x-optimade-metadata-definition:
   title: "Metadata for the _cheminfo_smiles field"
   description: "This dictionary contains the per-entry metadata for the _cheminfo_smiles field."
   x-optimade-type: "dictionary"
-  x-optimade-unit: "inapplicable"
   type:
     - "object"
     - "null"
@@ -32,11 +31,12 @@ x-optimade-metadata-definition:
     _cheminfo_standard:
       description: |-
         A name of the standard the given SMILES string conforms to.
+      x-optimade-type: "string"
+      type:
+        - "string"
       examples:
         - "OpenSMILES"
         - "IUPAC SMILES+"
-      x-optimade-type:
-        - "string"
-        - "null"
       x-optimade-unit: "inapplicable"
+  x-optimade-unit: "inapplicable"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -1,6 +1,6 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
 $id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_smiles"
-title: "SMILES"
+title: "SMILES (Simplified Molecular Input Line Entry Specification) representation of the structure"
 x-optimade-type: "string"
 x-optimade-definition:
   kind: "property"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -1,0 +1,18 @@
+$$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
+$id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_smiles"
+title: "SMILES"
+x-optimade-type: "string"
+x-optimade-definition:
+  kind: "property"
+  version: "0.1.0"
+  format: "1.2"
+  name: "_cheminfo_smiles"
+  label: "_cheminfo_smiles_structures"
+type:
+  - "string"
+  - "null"
+description: |-
+  SMILES string describing a chemical compound.
+examples:
+  - "c1ccccc1"
+x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -28,9 +28,9 @@ x-optimade-metadata-definition:
     - "object"
     - "null"
   properties:
-    _cheminfo_standard_name:
+    _cheminfo_specification_name:
       description: |-
-        A name of the standard the given SMILES string conforms to.
+        A name of the specification the given SMILES string conforms to.
         Takes value from an enumeration set containing 'IUPAC SMILES+' (https://github.com/IUPAC/IUPAC_SMILES_plus), 'OpenSMILES' (http://opensmiles.org/opensmiles.html) and 'other' (none of the above).
       x-optimade-type: "string"
       type:
@@ -43,9 +43,9 @@ x-optimade-metadata-definition:
         - "IUPAC SMILES+"
         - "OpenSMILES"
       x-optimade-unit: "inapplicable"
-    _cheminfo_standard_name_other:
+    _cheminfo_specification_name_other:
       description: |-
-        A name of the standard the given SMILES string conforms to, if different from the enumerator values for '_cheminfo_standard_name'.
+        A name of the specification the given SMILES string conforms to, if different from the enumerator values for '_cheminfo_specification_name'.
       x-optimade-type: "string"
       type:
         - "string"
@@ -53,10 +53,10 @@ x-optimade-metadata-definition:
         - "Daylight"
         - "OpenBabel"
       x-optimade-unit: "inapplicable"
-    _cheminfo_standard_version:
+    _cheminfo_specification_version:
       description: |-
-        The version of the SMILES standard given in '_cheminfo_standard_name'.
-        If '_cheminfo_standard_name_other' contains the name of a software library used to generate SMILES, '_cheminfo_standard_version' MUST be the version of this software library.
+        The version of the SMILES specification given in '_cheminfo_specification_name'.
+        If '_cheminfo_specification_name_other' contains the name of a software library used to generate SMILES, '_cheminfo_specification_version' MUST be the version of this software library.
       x-optimade-type: "string"
       type:
         - "string"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -1,6 +1,6 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
 $id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_smiles"
-title: "SMILES (Simplified Molecular Input Line Entry Specification) representation of the structure"
+title: "SMILES (Simplified Molecular Input Line Entry System) representation of the structure"
 x-optimade-type: "string"
 x-optimade-definition:
   kind: "property"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -28,15 +28,20 @@ x-optimade-metadata-definition:
     - "object"
     - "null"
   properties:
-    _cheminfo_standard:
+    _cheminfo_standard_name:
       description: |-
         A name of the standard the given SMILES string conforms to.
+        Takes value from an enumerator containing: 'IUPAC SMILES+' (https://github.com/IUPAC/IUPAC_SMILES_plus), 'OpenSMILES' (http://opensmiles.org/opensmiles.html) and 'other' (none of the above).
       x-optimade-type: "string"
       type:
         - "string"
-      examples:
-        - "OpenSMILES"
+      enum:
         - "IUPAC SMILES+"
+        - "OpenSMILES"
+        - "other"
+      examples:
+        - "IUPAC SMILES+"
+        - "OpenSMILES"
       x-optimade-unit: "inapplicable"
   x-optimade-unit: "inapplicable"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -20,4 +20,23 @@ description: |-
 examples:
   - "c1ccccc1"
   - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+x-optimade-metadata-definition:
+  title: "Metadata for the _cheminfo_smiles field"
+  description: "This dictionary contains the per-entry metadata for the _cheminfo_smiles field."
+  x-optimade-type: "dictionary"
+  x-optimade-unit: "inapplicable"
+  type:
+    - "object"
+    - "null"
+  properties:
+    _cheminfo_standard:
+      description: |-
+        A name of a standard the given SMILES string conforms to.
+      examples:
+        - "OpenSMILES"
+        - "IUPAC SMILES+"
+      x-optimade-type:
+        - "string"
+        - "null"
+      x-optimade-unit: "inapplicable"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -13,13 +13,12 @@ type:
   - "null"
 description: |-
   SMILES (Simplified Molecular Input Line Entry System) representation of the structure.
-  Values are RECOMMENDED to adhere to the OpenSMILES specification v1.0 (http://opensmiles.org/opensmiles.html).
-  When structures or their parts cannot be unambiguously represented in SMILES according to OpenSMILES recommendations, using the guidelines from Quirós et al. 2018 (https://doi.org/10.1186/s13321-018-0279-6) is RECOMMENDED.
   Providers MAY canonicalize (i.e., use rules to establish the stable order of atoms) the produced SMILES representations, but this is not mandatory and no particular set of rules is recommended.
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
 examples:
   - "c1ccccc1"
   - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+  - "[Na+].[Cl-]"
 x-optimade-metadata-definition:
   title: "Metadata for the _cheminfo_smiles field"
   description: "This dictionary contains the per-entry metadata for the _cheminfo_smiles field."

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -19,4 +19,5 @@ description: |-
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
 examples:
   - "c1ccccc1"
+  - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -13,7 +13,7 @@ type:
   - "null"
 description: |-
   SMILES (Simplified Molecular Input Line Entry System) representation of the structure.
-  Values MUST adhere to the OpenSMILES specification v1.0 (http://opensmiles.org/opensmiles.html).
+  Values are RECOMMENDED to adhere to the OpenSMILES specification v1.0 (http://opensmiles.org/opensmiles.html).
   When structures or their parts cannot be unambiguously represented in SMILES according to OpenSMILES recommendations, using the guidelines from Quirós et al. 2018 (https://doi.org/10.1186/s13321-018-0279-6) is RECOMMENDED.
   Providers MAY canonicalize (i.e., use rules to establish the stable order of atoms) the produced SMILES representations, but this is not mandatory and no particular set of rules is recommended.
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -15,6 +15,11 @@ description: |-
   SMILES (Simplified Molecular Input Line Entry System) representation of the structure.
   Providers MAY canonicalize (i.e., use rules to establish the stable order of atoms) the produced SMILES representations, but this is not mandatory and no particular set of rules is recommended.
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
+
+  In the filtering context, this field behaves differently to a normal string.
+  Firstly, this property can be used with the `CONTAINS` operator to provide a substructure query using the  SMILES Arbitrary Target Specification (SMARTS) language defined in the Daylight SMARTS documentation (https://www.daylight.com/dayhtml/doc/theory/theory.smarts.html).
+  Secondly, exact matches using the `=` operator have additional semantics that allow a server to canonicalize the SMILES value before performing the exact match comparison, i.e., a server implementation SHOULD attempt to convert a user query for an exact SMILES match into the particular SMILES format used by the database, whereupon it can return entries that have SMILES data that matches at the semantic rather than lexical level.
+
 examples:
   - "c1ccccc1"
   - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -17,9 +17,8 @@ description: |-
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
 
   In the filtering context, this field behaves differently to a normal string.
-  Firstly, this property can be used with the `CONTAINS` operator to provide a substructure query using the  SMILES Arbitrary Target Specification (SMARTS) language defined in the Daylight SMARTS documentation (https://www.daylight.com/dayhtml/doc/theory/theory.smarts.html).
+  Firstly, this property can be used with the `CONTAINS` operator to provide a substructure query using the SMILES Arbitrary Target Specification (SMARTS) language defined in the Daylight SMARTS documentation (https://www.daylight.com/dayhtml/doc/theory/theory.smarts.html).
   Secondly, exact matches using the `=` operator have additional semantics that allow a server to canonicalize the SMILES value before performing the exact match comparison, i.e., a server implementation SHOULD attempt to convert a user query for an exact SMILES match into the particular SMILES format used by the database, whereupon it can return entries that have SMILES data that matches at the semantic rather than lexical level.
-
 examples:
   - "c1ccccc1"
   - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -56,7 +56,6 @@ x-optimade-metadata-definition:
     _cheminfo_standard_version:
       description: |-
         The version of the SMILES standard given in '_cheminfo_standard_name'.
-        MUST NOT contain the initial 'v' or 'V'.
         If '_cheminfo_standard_name_other' contains the name of a software library used to generate SMILES, '_cheminfo_standard_version' MUST be the version of this software library.
       x-optimade-type: "string"
       type:

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -51,6 +51,7 @@ x-optimade-metadata-definition:
     _cheminfo_specification_name_other:
       description: |-
         A name of the specification the given SMILES string conforms to, if different from the enumerator values for '_cheminfo_specification_name'.
+        MUST be defined (non-NULL) if and only if the value for '_cheminfo_specification_name' is known and is equal to 'other'.
       x-optimade-type: "string"
       type:
         - "string"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -70,5 +70,16 @@ x-optimade-metadata-definition:
         - "1.0"
         - "a76e26b32e6f0d18f7dd0cadf1b23449baebb04e"
       x-optimade-unit: "inapplicable"
+    _cheminfo_special_details:
+      description: |-
+        Other details related to SMILES treatment by the provider that might need relaying.
+        For example, a provider might want to express that stereochemistry is not represented in this SMILES string.
+      x-optimade-type: "string"
+      type:
+        - "string"
+        - "null"
+      examples:
+        - "Stereochemistry is not represented"
+      x-optimade-unit: "inapplicable"
   x-optimade-unit: "inapplicable"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -1,7 +1,7 @@
 $$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
 $id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_smiles"
 title: "SMILES (Simplified Molecular Input Line Entry System) representation of the structure"
-x-optimade-type: "_cheminfo_smiles"
+x-optimade-type: "string"
 x-optimade-definition:
   kind: "property"
   version: "0.1.0"
@@ -15,11 +15,6 @@ description: |-
   SMILES (Simplified Molecular Input Line Entry System) representation of the structure.
   Providers MAY canonicalize (i.e., use rules to establish the stable order of atoms) the produced SMILES representations, but this is not mandatory and no particular set of rules is recommended.
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
-
-  In the filtering context, this field behaves differently to a normal string.
-  Firstly, this property can be used with the `CONTAINS` operator to provide a substructure query using the SMILES Arbitrary Target Specification (SMARTS) language defined in the Daylight SMARTS documentation (https://www.daylight.com/dayhtml/doc/theory/theory.smarts.html).
-  Secondly, exact matches using the `=` operator have additional semantics that allow a server to canonicalize the SMILES value before performing the exact match comparison, i.e., a server implementation SHOULD attempt to convert a user query for an exact SMILES match into the particular SMILES format used by the database, whereupon it can return entries that have SMILES data that matches at the semantic rather than lexical level.
-  Finally, `IS KNOWN` and `IS UNKNOWN` operators MAY be used to filter entries having non-`null` and `null` values of this property, accordingly.
 examples:
   - "c1ccccc1"
   - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -15,6 +15,7 @@ description: |-
   SMILES (Simplified Molecular Input Line Entry System) representation of the structure.
   Providers MAY canonicalize (i.e., use rules to establish the stable order of atoms) the produced SMILES representations, but this is not mandatory and no particular set of rules is recommended.
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
+  No particular specification (also known as flavor) for the provided SMILES strings is enforced, but if known, MUST be provided in metadata property '_cheminfo_specification_name'.
 examples:
   - "c1ccccc1"
   - "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
@@ -32,6 +33,7 @@ x-optimade-metadata-definition:
         A name of the specification the given SMILES string conforms to.
         Takes value from an enumeration set containing 'IUPAC SMILES+' (https://github.com/IUPAC/IUPAC_SMILES_plus), 'OpenSMILES' (http://opensmiles.org/opensmiles.html) and 'other' (none of the above).
         If 'other' is chosen, the specification MUST be specified in metadata property '_cheminfo_specification_name_other'.
+        'null' value means that the specification of the given SMILES string is not known.
       x-optimade-type: "string"
       type:
         - "string"

--- a/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_smiles.yaml
@@ -13,6 +13,7 @@ type:
   - "null"
 description: |-
   SMILES (Simplified Molecular Input Line Entry System) representation of the structure.
+  Property is string-valued, thus comparison operators (only '=' and '!=' are allowed) MUST compare literal strings.
   Providers MAY canonicalize (i.e., use rules to establish the stable order of atoms) the produced SMILES representations, but this is not mandatory and no particular set of rules is recommended.
   Generally, providers SHOULD NOT change the representation more frequently than the structure itself is modified.
   No particular specification (also known as flavor) for the provided SMILES strings is enforced, but if known, MUST be provided in metadata property '_cheminfo_specification_name'.


### PR DESCRIPTION
This PR is meant to serve as a base for discussion around introducing SMILES property for structures in cheminformatics namespace. I have taken the liberty to copy-paste my earlier attempt to introduce SMILES into the main OPTIMADE specification (https://github.com/Materials-Consortia/OPTIMADE/pull/392). I am aware that for some of the points there is no consensus:

1. String or special SMILES data type (see https://github.com/Materials-Consortia/OPTIMADE/pull/436 for data type and https://github.com/Materials-Consortia/OPTIMADE/pull/533 for property-specific `SEARCH` operator which could in this case support SMARTS searches)
2. One-valued or list-valued (personally I see little use of lists as SMILES define `.` as separator of unconnected molecular entities)
3. OpenSMILES, [IUPAC SMILES+](https://github.com/IUPAC/IUPAC_SMILES_plus) or something else
4. [Quirós et al. 2018](https://doi.org/10.1186/s13321-018-0279-6) or no additional recommendations where SMILES is ambiguous.

Tagging the people who showed interest in SMILES in OPTIMADE: @ml-evs @vaitkus @alex-belozerov @sauliusg @JPBergsma @rartino. Please tag those who I forgot.