### PR TITLE
Introduce `_cheminfo_stdinchi` property

### DIFF
--- a/src/v0.1.0/entrytypes/structures.yaml
+++ b/src/v0.1.0/entrytypes/structures.yaml
@@ -23,6 +23,13 @@ properties:
       sortable: false
       query-support: "none"
       response-level: "yes"
+  _cheminfo_stdinchi:
+    $$inherit: "/properties/structures/_cheminfo_stdinchi"
+    x-optimade-implementation:
+      support: "may"
+      sortable: false
+      query-support: "none"
+      response-level: "yes"
   _cheminfo_stdinchikey:
     $$inherit: "/properties/structures/_cheminfo_stdinchikey"
     x-optimade-implementation:

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchi.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchi.yaml
@@ -1,0 +1,19 @@
+$$schema: "https://schemas.optimade.org/meta/v1.2/optimade/property_definition"
+$id: "https://schemas.optimade.org/namespaces/cheminformatics/v0.1/properties/structures/_cheminfo_stdinchi"
+title: "The standard InChI identifier of the structure as defined by the InChI Trust"
+x-optimade-type: "string"
+x-optimade-definition:
+  kind: "property"
+  version: "0.1.0"
+  format: "1.2"
+  name: "_cheminfo_stdinchi"
+  label: "_cheminfo_stdinchi_structures"
+type:
+  - "string"
+  - "null"
+description: |-
+  The standard InChI identifier of the structure as defined by the InChI Trust (https://www.inchi-trust.org).
+  The value MUST start with `InChI=1S/`.
+examples:
+  - "InChI=1S/C10H12N2O/c11-4-3-7-6-12-10-2-1-8(13)5-9(7)10/h1-2,5-6,12-13H,3-4,11H2"
+x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchi.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchi.yaml
@@ -16,4 +16,23 @@ description: |-
   The value MUST start with `InChI=1S/`.
 examples:
   - "InChI=1S/C10H12N2O/c11-4-3-7-6-12-10-2-1-8(13)5-9(7)10/h1-2,5-6,12-13H,3-4,11H2"
+x-optimade-metadata-definition:
+  title: "Metadata for the _cheminfo_stdinchi field"
+  description: "This dictionary contains the per-entry metadata for the _cheminfo_stdinchi field."
+  x-optimade-type: "dictionary"
+  type:
+    - "object"
+    - "null"
+  properties:
+    _cheminfo_library_version:
+      description: |-
+        The version of the InChI software library used to generate this standard InChI value.
+        MUST NOT start with 'v'.
+      x-optimade-type: "string"
+      type:
+        - "string"
+      examples:
+        - "1.07.4"
+      x-optimade-unit: "inapplicable"
+  x-optimade-unit: "inapplicable"
 x-optimade-unit: "inapplicable"

--- a/src/v0.1.0/properties/structures/_cheminfo_stdinchi.yaml
+++ b/src/v0.1.0/properties/structures/_cheminfo_stdinchi.yaml
@@ -13,7 +13,7 @@ type:
   - "null"
 description: |-
   The standard InChI identifier of the structure as defined by the InChI Trust (https://www.inchi-trust.org).
-  The value MUST start with `InChI=1S/`.
+  The value MUST start with `InChI=`.
 examples:
   - "InChI=1S/C10H12N2O/c11-4-3-7-6-12-10-2-1-8(13)5-9(7)10/h1-2,5-6,12-13H,3-4,11H2"
 x-optimade-metadata-definition:
@@ -26,7 +26,7 @@ x-optimade-metadata-definition:
   properties:
     _cheminfo_library_version:
       description: |-
-        The version of the InChI software library used to generate this standard InChI value.
+        The version of the InChI software library (https://github.com/IUPAC-InChI/InChI) used to generate this standard InChI value.
         MUST NOT start with 'v'.
       x-optimade-type: "string"
       type:


### PR DESCRIPTION
This PR introduces standard InChI property (`_cheminfo_stdinchi`) as discussed on Tuesday-Wednesday during the OPTIMADE meeting.